### PR TITLE
avoid race condition that led to many simultaneous loads of the globa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+### 2.1.0: fixed significant performance issue caused by simultaneous attempts to fetch the `global` doc in order to find default orderings. **You must also upgrade apostrophe to version 2.85.0 or better** for this version to work properly.
+
 ### 2.0.3: bug fixed in which `req` was not passed on to the parent class version of `getCreateSingletonOptions`, leading to crashes in certain situations.
 
 ### 2.0.2: documentation includes examples for editors; changed browse button label from "Pieces" to "Items" as "Pieces" is not usually language shared with editors. No other code changes.

--- a/lib/modules/apostrophe-pieces-orderings-pieces/lib/cursor.js
+++ b/lib/modules/apostrophe-pieces-orderings-pieces/lib/cursor.js
@@ -33,19 +33,27 @@ module.exports = {
           function body(callback) {
             if (self.get('ordering') === true) {
               // Default ordering requires global doc, which might not
-              // be present in req in a task context
-              return self.apos.global.addGlobalToData(self.get('req'), function(err) {
+              // be present in req in a task context. We look at `req.aposGlobalCore`
+              // because it is populated *before* any joins from global are loaded, avoiding
+              // recursion and race conditions. The default orderings live directly in
+              // the global doc and don't have to wait for the joins
+              if (!req.aposGlobalCore) {
+                return self.apos.global.addGlobalToData(self.get('req'), body);
+              } else {
+                return body(null);
+              }
+              function body(err) {
                 if (err) {
                   return callback(err);
                 }
                 // Might or might not have a default ordering, find out
-                self.set('ordering', req.data.global && req.data.global.piecesOrderings && req.data.global.piecesOrderings[self.options.module.name]);
+                self.set('ordering', req.aposGlobalCore && req.aposGlobalCore.piecesOrderings && req.aposGlobalCore.piecesOrderings[self.options.module.name]);
                 if (!self.get('ordering')) {
                   return superLowLevelMongoCursor(req, criteria, projection, options).toArray(callback);
                 }
                 // Yes we have the default ordering now
                 return inner(callback);
-              });
+              }
             } else {
               // Already a particular ordering object
               return inner(callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-pieces-orderings-bundle",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Sort your pieces in a handpicked order. Create multiple orderings and associate them with particular pieces-pages. You can also make one the optimized default sort.",
   "main": "index.js",
   "scripts": {
@@ -12,6 +12,8 @@
   },
   "keywords": [
     "apostrophecms",
+    "apostrophe-cms",
+    "apostrophe",
     "pieces",
     "order",
     "featured",


### PR DESCRIPTION
…l doc due to joins present in the global doc

We do this by looking at the global doc before its joins are performed, and not requesting it redundantly if at least that much of it is already available. Default orderings are direct properties of the global doc so they don't need joins.

Corresponding apostrophe PR to be opened in a moment.